### PR TITLE
Added the delete method to the request object

### DIFF
--- a/lib/eventbrite_api/request.rb
+++ b/lib/eventbrite_api/request.rb
@@ -20,6 +20,11 @@ class EventbriteAPI
       Response.new(response)
     end
 
+    def delete
+      response = self.class.delete(path, query: query).body
+      Response.new(response)
+    end
+
     def method_missing(method, *args)
       params = args[0].is_a?(Hash) ? args[0] : {}
       route, token = path.split("?")


### PR DESCRIPTION
In the new eventbrite api, some requests require the 'delete' method
